### PR TITLE
Fix CORS error handling

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -16,6 +16,11 @@ export const getPostByID = async (id) => {
   const metadata = await axios.get(post.metadataURI);
   post.metadata = metadata.data;
 
+  // Only show Zora posts
+  if (post.metadata.version !== "zora-20210101") {
+    return undefined;
+  }
+
   // If text media, collect post content
   if (metadata.data.mimeType.startsWith("text")) {
     const text = await axios.get(post.contentURI);

--- a/data/index.js
+++ b/data/index.js
@@ -2,8 +2,8 @@ import { GraphQLClient } from "graphql-request"; // GraphQL request client
 
 // Create client
 const client = new GraphQLClient(
-  // Zora mainnet subgraph
-  "https://api.thegraph.com/subgraphs/name/ourzora/zora-v1"
+  // Zora Rinkeby subgraph
+  "https://api.thegraph.com/subgraphs/name/ourzora/zora-v1-rinkeby"
 );
 
 // Export client

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,8 +26,9 @@ export default function Home() {
       for (let i = numPosts; i >= numPosts - 5; i--) {
         // Collect post
         const post = await getPostByID(i);
+
         // Push post to initialPosts
-        if (post !== null) {
+        if (post != null) {
           initialPosts.push(post);
         }
       }
@@ -52,7 +53,7 @@ export default function Home() {
         // Collect post
         const post = await getPostByID(i);
         // Push post to newPosts
-        if (post !== null) {
+        if (post != null) {
           newPosts.push(post);
         }
       }

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,7 +27,9 @@ export default function Home() {
         // Collect post
         const post = await getPostByID(i);
         // Push post to initialPosts
-        initialPosts.push(post);
+        if (post !== null) {
+          initialPosts.push(post);
+        }
       }
     }
 
@@ -50,7 +52,9 @@ export default function Home() {
         // Collect post
         const post = await getPostByID(i);
         // Push post to newPosts
-        newPosts.push(post);
+        if (post !== null) {
+          newPosts.push(post);
+        }
       }
     }
 


### PR DESCRIPTION
A zNFT was minted on Rinkeby with URIs pointing to google's servers.

The error:
`Access to XMLHttpRequest at 'https://storage.googleapis.com/nft-canvas/1/7/metadata.json' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.`

Solution Source:
https://github.com/prisma-labs/graphql-request/blob/master/examples/error-handling.ts